### PR TITLE
fix: modify postgresAdapter to reuse connections for successive queries

### DIFF
--- a/lib/adapters/postgresAdapter.js
+++ b/lib/adapters/postgresAdapter.js
@@ -17,8 +17,8 @@ pool.on('error', (err, client) => {
   console.error('Unexpected error on idle postgres client', err);
 });
 
-async function getThumbs(pageId, userId) {
-  const { rows } = await pool.query(
+async function selectThumbs(client, pageId, userId) {
+  const { rows } = await client.query(
     "SELECT thumbs_up, thumbs_down, user_thumb_up FROM total_thumbs($1, $2)",
     [pageId, userId]
   );
@@ -26,19 +26,29 @@ async function getThumbs(pageId, userId) {
 }
 
 async function setThumb(pageId, userId, thumbUp) {
-  const { rows } = await pool.query(
-    "INSERT INTO thumbs_up(page_id, github_user, thumb_up) VALUES($1, $2, $3)",
-    [pageId, userId, thumbUp]
-  );
-  return rows[0];
+  const client = await pool.connect();
+  try {
+    await client.query(
+      "INSERT INTO thumbs_up(page_id, github_user, thumb_up) VALUES($1, $2, $3)",
+      [pageId, userId, thumbUp]
+    );
+    return selectThumbs(client, pageId, userId);
+  } finally {
+    client.release();
+  }
 }
 
 async function deleteThumb(pageId, userId) {
-  const { rows } = await pool.query(
-    "DELETE FROM thumbs_up WHERE page_id = $1 AND github_user = $2",
-    [pageId, userId]
-  );
-  return rows[0];
+  const client = await pool.connect();
+  try {
+    await client.query(
+      "DELETE FROM thumbs_up WHERE page_id = $1 AND github_user = $2",
+      [pageId, userId]
+    );
+    return selectThumbs(client, pageId, userId);
+  } finally {
+    client.release();
+  }
 }
 
 async function getTopPages(thumbType = "up", limit = 10) {
@@ -55,7 +65,7 @@ async function getTopPages(thumbType = "up", limit = 10) {
 }
 
 module.exports = {
-  getThumbs,
+  getThumbs: selectThumbs.bind(null, pool),
   setThumb,
   deleteThumb,
   getTopPages

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -29,16 +29,17 @@ function convertSentimentToThumb(sentiment) {
 }
 
 async function getThumbsForPage(req, res) {
-  const { token } = req.cookies;
   const { pageId } = req.query;
   if (!pageId) {
     res.status(500).send("pageId missing");
   }
-  console.log("Getting thumbs for", pageId);
+
+  const { token } = req.cookies;
   let userId = null;
   if (token) {
     userId = await github.getUserId(token);
   }
+  console.log("Getting thumbs for", pageId);
 
   return pgAdapter
     .getThumbs(pageId, userId)
@@ -47,34 +48,36 @@ async function getThumbsForPage(req, res) {
 }
 
 async function setThumbForPage(req, res) {
-  const { token } = req.cookies;
   const { pageId, userThumb } = req.body;
-  const userId = await github.getUserId(token);
   if (!pageId) {
     res.status(500).send("pageId missing");
   }
-  console.log("Setting thumbs for", pageId);
-
-  if (userThumb === "thumbUp") {
-    pgAdapter.setThumb(pageId, userId, true);
-  } else if (userThumb === "thumbDown") {
-    pgAdapter.setThumb(pageId, userId, false);
+  if (![ "thumbUp", "thumbDown" ].includes(userThumb)) {
+    res.status(500).send("userThumb invalid");
   }
 
+  const { token } = req.cookies;
+  const userId = await github.getUserId(token);
+  console.log("Setting thumbs for", pageId);
+
   return pgAdapter
-    .getThumbs(pageId, userId)
+    .setThumb(pageId, userId, userThumb === "thumbUp")
     .then(thumbsToReadable)
     .then(thumbs => res.send(thumbs));
 }
 
 async function removeThumbForPage(req, res) {
-  const { token } = req.cookies;
   const { pageId } = req.query;
+  if (!pageId) {
+    res.status(500).send("pageId missing");
+  }
+
+  const { token } = req.cookies;
   const userId = await github.getUserId(token);
+  console.log("Removing thumbs for", pageId);
 
   return pgAdapter
     .deleteThumb(pageId, userId)
-    .then(() => pgAdapter.getThumbs(pageId, userId))
     .then(thumbsToReadable)
     .then(thumbs => res.send(thumbs));
 }


### PR DESCRIPTION
This is necessary to ensure that the updates made in the set/removeThumbForPage functions (in lib/routes.js) are always reflected in the data they return.