### PR TITLE
Fix/enable cors

### DIFF
--- a/lib/adapters/postgresAdapter.js
+++ b/lib/adapters/postgresAdapter.js
@@ -1,6 +1,5 @@
 const { Pool } = require("pg");
 const { dbHost, dbPassword, dbUser } = require("../../settings");
-const { badRequest } = require("../errors");
 
 const pool = new Pool({
   user: dbUser,
@@ -52,10 +51,6 @@ async function deleteThumb(pageId, userId) {
 }
 
 async function getTopPages(thumbType = "up", limit = 10) {
-  const validTypes = [ "up", "down", "net" ];
-  if (!validTypes.includes(thumbType)) {
-    badRequest(`"${thumbType}" is not one of [${validTypes.join(", ")}]`);
-  }
   const top_thumbs = "top_thumbs_" + thumbType;
   const { rows } = await pool.query(
     `SELECT page_id, thumbs_up, thumbs_down FROM ${top_thumbs}($1)`,

--- a/lib/index.js
+++ b/lib/index.js
@@ -2,7 +2,8 @@ const express = require("express");
 const app = express();
 const bodyParser = require("body-parser");
 const cookieParser = require("cookie-parser");
-const asyncHandler = require('express-async-handler')
+const asyncHandler = require('express-async-handler');
+const cors = require('cors');
 
 const {
   redirectToAuthUrl,
@@ -35,7 +36,7 @@ app.get("/thumbs", asyncHandler(getThumbsForPage));
 app.post("/thumbs", asyncHandler(setThumbForPage));
 app.delete("/thumbs", asyncHandler(removeThumbForPage));
 
-app.get("/top-pages", asyncHandler(getTopPagesByThumbs));
+app.get("/top-pages", cors(), asyncHandler(getTopPagesByThumbs));
 
 app.use(errorHandler);
 app.use(express.static("public"));

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -1,11 +1,11 @@
 const pgAdapter = require("./adapters/postgresAdapter");
 const github = require("./adapters/github");
 const oauth = require("./oauth");
+const { badRequest } = require("./errors");
 
 function redirectToAuthUrl(req, res) {
   const { redirect_uri: endUserUrl } = req.query;
   const authUrl = oauth.getAuthUrl(endUserUrl);
-
   return res.redirect(authUrl);
 }
 
@@ -24,70 +24,63 @@ function convertSentimentToThumb(sentiment) {
   if (sentiment === null) {
     return null;
   }
-
   return sentiment ? "thumbUp" : "thumbDown";
 }
 
 async function getThumbsForPage(req, res) {
   const { pageId } = req.query;
   if (!pageId) {
-    res.status(500).send("pageId missing");
+    badRequest("pageId missing");
   }
-
   const { token } = req.cookies;
   let userId = null;
   if (token) {
     userId = await github.getUserId(token);
   }
-  console.log("Getting thumbs for", pageId);
 
-  return pgAdapter
-    .getThumbs(pageId, userId)
-    .then(thumbsToReadable)
-    .then(thumbs => res.send(thumbs));
+  console.log("Getting thumbs for", pageId);
+  const thumbs = await pgAdapter.getThumbs(pageId, userId);
+  res.send(thumbsToReadable(thumbs));
 }
 
 async function setThumbForPage(req, res) {
   const { pageId, userThumb } = req.body;
   if (!pageId) {
-    res.status(500).send("pageId missing");
+    badRequest("pageId missing");
   }
   if (![ "thumbUp", "thumbDown" ].includes(userThumb)) {
-    res.status(500).send("userThumb invalid");
+    badRequest("userThumb invalid");
   }
-
   const { token } = req.cookies;
   const userId = await github.getUserId(token);
-  console.log("Setting thumbs for", pageId);
 
-  return pgAdapter
-    .setThumb(pageId, userId, userThumb === "thumbUp")
-    .then(thumbsToReadable)
-    .then(thumbs => res.send(thumbs));
+  console.log("Setting thumbs for", pageId);
+  const thumbs = await pgAdapter.setThumb(pageId, userId, userThumb === "thumbUp");
+  res.send(thumbsToReadable(thumbs));
 }
 
 async function removeThumbForPage(req, res) {
   const { pageId } = req.query;
   if (!pageId) {
-    res.status(500).send("pageId missing");
+    badRequest("pageId missing");
   }
-
   const { token } = req.cookies;
   const userId = await github.getUserId(token);
-  console.log("Removing thumbs for", pageId);
 
-  return pgAdapter
-    .deleteThumb(pageId, userId)
-    .then(thumbsToReadable)
-    .then(thumbs => res.send(thumbs));
+  console.log("Removing thumb for", pageId);
+  const thumbs = await pgAdapter.deleteThumb(pageId, userId);
+  res.send(thumbsToReadable(thumbs));
 }
 
 async function getTopPagesByThumbs(req, res) {
   const { thumbs, limit } = req.query;
+  const validTypes = [ "up", "down", "net" ];
+  if (!validTypes.includes(thumbs)) {
+    badRequest(`thumbs is not one of [${validTypes.join(", ")}]`);
+  }
 
-  return pgAdapter
-    .getTopPages(thumbs, limit)
-    .then(pages => res.send(pages.map(thumbsToIntegers)));
+  const pages = await pgAdapter.getTopPages(thumbs, limit);
+  res.send(pages.map(thumbsToIntegers));
 }
 
 const thumbsToReadable = ({ thumbs_up, thumbs_down, user_thumb_up }) => ({

--- a/test/e2e/index.spec.js
+++ b/test/e2e/index.spec.js
@@ -296,3 +296,25 @@ describe("GET /thumbs", () => {
       });
   });
 });
+
+describe("GET /top-pages", () => {
+  const maxPages = 3;
+  it("should set the CORS header given some other origin", (done) => {
+    chai.request(app)
+    .get("/top-pages")
+    .set("Origin", "https://some.other.domain.com")
+    .query({
+      thumbs: "up",
+      limit: maxPages
+    })
+    .end((err, res) => {
+      expect(err).to.be.null;
+      expect(res).to.have.status(200);
+      expect(res).to.be.json;
+      expect(res.headers).to.have.property("access-control-allow-origin", "*");
+      expect(res.body).to.have.lengthOf.at.most(maxPages);
+      expect(res.body[0]).to.have.all.keys("pageId", "thumbsUp", "thumbsDown");
+      done();
+    });
+  });
+});


### PR DESCRIPTION
Unlike the other routes provided by this service, CORS must be enabled for GET /top-pages because it is intended to be called from outside the provided iframe.